### PR TITLE
Users now have the ability to search all posts by title

### DIFF
--- a/src/components/posts/AllPosts.js
+++ b/src/components/posts/AllPosts.js
@@ -7,6 +7,7 @@ export const AllPosts = () => {
     const [allPosts, setAllPosts] = useState([])
     const [allCategories, setAllCategories] = useState([])
     const [selectedCategory, setSelectedCategory] = useState("")
+    const [searchQuery, setSearchQuery] = useState("")
     const [error, setError] = useState(null)
 
     useEffect(()=> {
@@ -30,6 +31,9 @@ export const AllPosts = () => {
     const filteredPosts = selectedCategory ? allPosts.filter(post => 
         post.category_id === parseInt(selectedCategory)) : allPosts
 
+
+    const searchedPosts = searchQuery ? filteredPosts.filter(post => post.title.includes(searchQuery)) : filteredPosts
+
     return (
         <section>
             <h1 className="title is-3 has-text-centered">All Posts</h1>
@@ -43,6 +47,10 @@ export const AllPosts = () => {
                         ))}
                     </select>
                 </div>
+                <label>Search By Title: </label>
+                <div className="m-3">
+                        <input type="text" value={searchQuery} onChange={(event)=>{setSearchQuery(event.target.value)}} />
+                </div>
             </div>
             <div className="grid">
             <table className="cell is-hoverable">
@@ -54,7 +62,7 @@ export const AllPosts = () => {
                     </tr>
                 </thead>
                 <tbody>
-            {filteredPosts.map((post) => {
+            {searchedPosts.map((post) => {
                return <tr key={post.id} className="table is-bordered is-striped">
                     <td className=""><Link to={`/posts/${post.id}`}>{post.title}</Link></td>
                     <td className=""><Link to={`/users/${post.user_id}`}>{post.first_name} {post.last_name}</Link></td>

--- a/src/components/posts/AllPosts.js
+++ b/src/components/posts/AllPosts.js
@@ -32,7 +32,7 @@ export const AllPosts = () => {
         post.category_id === parseInt(selectedCategory)) : allPosts
 
 
-    const searchedPosts = searchQuery ? filteredPosts.filter(post => post.title.includes(searchQuery)) : filteredPosts
+    const searchedPosts = searchQuery ? filteredPosts.filter(post => post.title.toLowerCase().includes(searchQuery.toLowerCase())) : filteredPosts
 
     return (
         <section>


### PR DESCRIPTION
# Why and What?

Users should be able to search for specific posts using the post titles. 

Added a "Search By Title" search box to the All Posts View.

# How? 

Added a state to track the search query. Then, depending on whether a category has been selected, either all posts or filtered posts is filtered only to return posts that contain the search query in the title.

# Testing
-  In the browser, go to the all posts view.
- Type something in the search bar, were the posts filtered down to the relevant posts?
- Select a category to filter by, does the search query work while also filtering by categories?