### PR TITLE
added delete button to comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "rare-client",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/free-regular-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2061,6 +2063,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "peer": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -14895,6 +14940,36 @@
         "type-fest": {
           "version": "0.20.2"
         }
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "peer": true,
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "requires": {
+        "prop-types": "^15.8.1"
       }
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/free-regular-svg-icons": "^6.7.2",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/components/comments/CommentsView.js
+++ b/src/components/comments/CommentsView.js
@@ -1,17 +1,28 @@
 import { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
+import { deleteUserCommentById } from "../../services/commentService"
 
-export const CommentsView = () => {
+export const CommentsView = ({ token }) => {
     const [allPostComments, setAllPostComments] = useState([])
 
     const { postId } = useParams()
 
-    useEffect(() => {
+    const getAllPostComments = () => {
         fetch(`http://localhost:8088/comments/${postId}`)
         .then(response => response.json())
         .then(data => setAllPostComments(data))
         .catch(error => console.error("Error with fetching comments", error))
+    }
+
+    useEffect(() => {
+        getAllPostComments()
     }, [postId])
+
+    const deleteComment = (commentId) => {
+        deleteUserCommentById(commentId).then(() => {
+            getAllPostComments(postId)
+        })
+    }
 
     return (
         <section>
@@ -22,6 +33,9 @@ export const CommentsView = () => {
                         <div className="card m-5 p-3">
                         <div>"{comment.content}"</div>
                         <div>by: {comment.first_name} {comment.last_name}</div>
+                        {parseInt(token) === comment.author_id && (
+                            <button onClick={() => deleteComment(comment.id)} className="button is-danger m-2">🗑️</button>
+                        )}
                         </div>
                     </section>
                 )

--- a/src/services/commentService.js
+++ b/src/services/commentService.js
@@ -7,3 +7,15 @@ export const createNewComment = async (newCommentObj) => {
         body: JSON.stringify(newCommentObj)
     })
 }
+
+export const deleteUserCommentById = async (commentId) => {
+    const response = await fetch(`http://localhost:8088/comments/${commentId}`, {
+         method: "DELETE",
+         headers: {
+             "Content-Type": "application/json"
+         }
+     })
+ 
+     return response.ok
+     
+ }

--- a/src/views/ApplicationViews.js
+++ b/src/views/ApplicationViews.js
@@ -25,7 +25,7 @@ export const ApplicationViews = ({ token, setToken }) => {
         <Route path="/posts" >
             <Route index element={<AllPosts />} />
             <Route path=":postId" element={<PostDetails />} />
-            <Route path=":postId/comments" element={<CommentsView />} />
+            <Route path=":postId/comments" element={<CommentsView token={token} />} />
             <Route path=":postId/newComment" element={<NewComment token={token} />} />
         </Route>
         <Route path="/tags" element={<AllTags />} />


### PR DESCRIPTION
What?
Post comments can now be deleted only by the author of the comment.

Why?
Users can now add comments to posts and delete them, but are prevented from deleting other user's comments.

How?
This involved adding a deleteComment function and button in `CommentsView.js` module and a check to only display the delete button if the current user is the author of the comment. I also added a delete fetch call to the `commentService.js` module.

Testing?
-Starting in All Posts view, click on a post title to go to the Post Details page.
-Click on the "Add Comment" button and add a comment, you should be taken to the comments view page and see the new comment with a trash can icon under it.
-Click the trash can icon and the comment should no longer display on the page and should be removed from the database.